### PR TITLE
Fix a bug in ie

### DIFF
--- a/packages/web-rax-framework/src/appearRegistry.js
+++ b/packages/web-rax-framework/src/appearRegistry.js
@@ -217,18 +217,23 @@ export function getOffset(el, param) {
   if (!param) {
     param = {x: 0, y: 0};
   }
-
-  if (el != window) {
-    el = el.getBoundingClientRect();
-    l = el.left;
-    t = el.top;
-    r = el.right;
-    b = el.bottom;
-  } else {
+  
+  if (el === window) {
     l = 0;
     t = 0;
     r = l + el.innerWidth;
     b = t + el.innerHeight;
+  } else if (el.parentNode === null) {
+    l = 0;
+    t = 0;
+    r = 0;
+    b = 0;
+  } else {
+    const { top, right, bottom, left } = el.getBoundingClientRect();
+    l = left;
+    t = top;
+    r = right;
+    b = bottom;
   }
 
   return {


### PR DESCRIPTION
I have a case, use rax in ie, if el.parentNode === null,  mean el is node added to document, 
call getBoundingClientRect will throw error, another browser return { top: 0, right: 0... }
